### PR TITLE
Restrict node key/path mutation to a single case

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2018-10-25
+### Changed
+  * Restrict Json node creation to restrict key/path mutation to a single case
+  
 ## [0.2.0] - 2018-10-25
 ### Added
   * Explicit Json node types

--- a/src/JGami.php
+++ b/src/JGami.php
@@ -84,30 +84,31 @@ final class JGami
         return function ($kvPair): array {
             [$key, $path, $val] = (array)$kvPair;
 
+            $tplNode = new NullNode(new NodeKey($key), new NodePath($path));
             switch (JsonType::fromVal($val)->val()) {
                 case JsonType::OBJECT:
-                    $jsonNode = new ObjectNode(new NodeKey($key), new NodePath($path), $val);
+                    $jsonNode = ObjectNode::from($tplNode, $val);
                     $node = count((array)$val) > 0
                         ? Node::internalObject($jsonNode)
                         : Node::leaf($jsonNode);
                     return [$node, (array)$val];
                 case JsonType::ARRAY:
-                    $jsonNode = new ArrayNode(new NodeKey($key), new NodePath($path), $val);
+                    $jsonNode = ArrayNode::from($tplNode, $val);
                     $node = count($val) > 0
                         ? Node::internalArray($jsonNode)
                         : Node::leaf($jsonNode);
                     return [$node, $val];
                 case JsonType::BOOL:
-                    return [Node::leaf(new BoolNode(new NodeKey($key), new NodePath($path), $val)), []];
+                    return [Node::leaf(BoolNode::from($tplNode, $val)), []];
                 case JsonType::INT:
-                    return [Node::leaf(new IntNode(new NodeKey($key), new NodePath($path), $val)), []];
+                    return [Node::leaf(IntNode::from($tplNode, $val)), []];
                 case JsonType::FLOAT:
-                    return [Node::leaf(new FloatNode(new NodeKey($key), new NodePath($path), $val)), []];
+                    return [Node::leaf(FloatNode::from($tplNode, $val)), []];
                 case JsonType::STRING:
-                    return [Node::leaf(new StringNode(new NodeKey($key), new NodePath($path), $val)), []];
+                    return [Node::leaf(StringNode::from($tplNode, $val)), []];
                 case JsonType::NULL:
                 default:
-                    return [Node::leaf(new NullNode(new NodeKey($key), new NodePath($path))), []];
+                    return [Node::leaf($tplNode), []];
             }
         };
     }

--- a/src/Tree/Json/ArrayNode.php
+++ b/src/Tree/Json/ArrayNode.php
@@ -15,13 +15,6 @@ final class ArrayNode implements JsonNode
     /** @var array */
     private $val;
 
-    public function __construct(NodeKey $key, NodePath $path, array $val)
-    {
-        $this->key = $key;
-        $this->path = $path;
-        $this->val = $val;
-    }
-
     public static function from(JsonNode $node, array $val): self
     {
         return new self($node->key(), $node->path(), $val);
@@ -40,5 +33,15 @@ final class ArrayNode implements JsonNode
     public function val(): array
     {
         return $this->val;
+    }
+
+    private function __construct(
+        NodeKey $key,
+        NodePath $path,
+        array $val
+    ) {
+        $this->key = $key;
+        $this->path = $path;
+        $this->val = $val;
     }
 }

--- a/src/Tree/Json/BoolNode.php
+++ b/src/Tree/Json/BoolNode.php
@@ -15,13 +15,6 @@ final class BoolNode implements JsonNode
     /** @var bool */
     private $val;
 
-    public function __construct(NodeKey $key, NodePath $path, bool $val)
-    {
-        $this->key = $key;
-        $this->path = $path;
-        $this->val = $val;
-    }
-
     public static function from(JsonNode $node, bool $val): self
     {
         return new self($node->key(), $node->path(), $val);
@@ -40,5 +33,15 @@ final class BoolNode implements JsonNode
     public function val(): bool
     {
         return $this->val;
+    }
+
+    private function __construct(
+        NodeKey $key,
+        NodePath $path,
+        bool $val
+    ) {
+        $this->key = $key;
+        $this->path = $path;
+        $this->val = $val;
     }
 }

--- a/src/Tree/Json/FloatNode.php
+++ b/src/Tree/Json/FloatNode.php
@@ -15,13 +15,6 @@ final class FloatNode implements JsonNode
     /** @var float */
     private $val;
 
-    public function __construct(NodeKey $key, NodePath $path, float $val)
-    {
-        $this->key = $key;
-        $this->path = $path;
-        $this->val = $val;
-    }
-
     public static function from(JsonNode $node, float $val): self
     {
         return new self($node->key(), $node->path(), $val);
@@ -40,5 +33,15 @@ final class FloatNode implements JsonNode
     public function val(): float
     {
         return $this->val;
+    }
+
+    private function __construct(
+        NodeKey $key,
+        NodePath $path,
+        float $val
+    ) {
+        $this->key = $key;
+        $this->path = $path;
+        $this->val = $val;
     }
 }

--- a/src/Tree/Json/IntNode.php
+++ b/src/Tree/Json/IntNode.php
@@ -15,13 +15,6 @@ final class IntNode implements JsonNode
     /** @var int */
     private $val;
 
-    public function __construct(NodeKey $key, NodePath $path, int $val)
-    {
-        $this->key = $key;
-        $this->path = $path;
-        $this->val = $val;
-    }
-
     public static function from(JsonNode $node, int $val): self
     {
         return new self($node->key(), $node->path(), $val);
@@ -40,5 +33,15 @@ final class IntNode implements JsonNode
     public function val(): int
     {
         return $this->val;
+    }
+
+    private function __construct(
+        NodeKey $key,
+        NodePath $path,
+        int $val
+    ) {
+        $this->key = $key;
+        $this->path = $path;
+        $this->val = $val;
     }
 }

--- a/src/Tree/Json/ObjectNode.php
+++ b/src/Tree/Json/ObjectNode.php
@@ -16,13 +16,6 @@ final class ObjectNode implements JsonNode
     /** @var stdClass */
     private $val;
 
-    public function __construct(NodeKey $key, NodePath $path, stdClass $val)
-    {
-        $this->key = $key;
-        $this->path = $path;
-        $this->val = $val;
-    }
-
     public static function from(JsonNode $node, stdClass $val): self
     {
         return new self($node->key(), $node->path(), $val);
@@ -41,5 +34,15 @@ final class ObjectNode implements JsonNode
     public function val(): stdClass
     {
         return $this->val;
+    }
+
+    private function __construct(
+        NodeKey $key,
+        NodePath $path,
+        stdClass $val
+    ) {
+        $this->key = $key;
+        $this->path = $path;
+        $this->val = $val;
     }
 }

--- a/src/Tree/Json/StringNode.php
+++ b/src/Tree/Json/StringNode.php
@@ -15,13 +15,6 @@ final class StringNode implements JsonNode
     /** @var string */
     private $val;
 
-    public function __construct(NodeKey $key, NodePath $path, string $val)
-    {
-        $this->key = $key;
-        $this->path = $path;
-        $this->val = $val;
-    }
-
     public static function from(JsonNode $node, string $val): self
     {
         return new self($node->key(), $node->path(), $val);
@@ -40,5 +33,15 @@ final class StringNode implements JsonNode
     public function val(): string
     {
         return $this->val;
+    }
+
+    private function __construct(
+        NodeKey $key,
+        NodePath $path,
+        string $val
+    ) {
+        $this->key = $key;
+        $this->path = $path;
+        $this->val = $val;
     }
 }

--- a/tests/unit/JGamiTest.php
+++ b/tests/unit/JGamiTest.php
@@ -71,11 +71,13 @@ final class JGamiTest extends TestCase
     {
         $jsonString = '{"key": 1}';
 
+        // This is the only way to violate key/path integrity, ie. to purposefully
+        // use a new NullNode with custom key/path as a template
         $changeKey = function (JsonNode $node): JsonNode {
-            return new IntNode(new NodeKey('new-key'), $node->path(), 2);
+            return IntNode::from(new NullNode(new NodeKey('new-key'), $node->path()), 2);
         };
         $changePath = function (JsonNode $node): JsonNode {
-            return new IntNode($node->key(), new NodePath('new-path'), 2);
+            return IntNode::from(new NullNode($node->key(), new NodePath('new-path')), 2);
         };
 
         try {

--- a/tests/unit/Tree/Json/ArrayNodeTest.php
+++ b/tests/unit/Tree/Json/ArrayNodeTest.php
@@ -12,26 +12,14 @@ final class ArrayNodeTest extends TestCase
     /**
      * @test
      */
-    public function it_creates(): void
-    {
-        $node = new ArrayNode(new NodeKey('key'), new NodePath('path'), ['foo']);
-
-        self::assertInstanceOf(ArrayNode::class, $node);
-        self::assertSame('key', $node->key()->val());
-        self::assertSame('path', $node->path()->val());
-        self::assertSame(['foo'], $node->val());
-    }
-
-    /**
-     * @test
-     */
     public function it_creates_from_another_json_node(): void
     {
-        $node1 = new ArrayNode(new NodeKey('key'), new NodePath('path'), ['foo']);
-        $node2 = ArrayNode::from($node1, ['bar']);
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = ArrayNode::from($tplNode, ['bar']);
 
-        self::assertTrue($node2->key()->eq($node1->key()->val()));
-        self::assertTrue($node2->path()->eq($node1->path()->val()));
-        self::assertSame(['bar'], $node2->val());
+        self::assertInstanceOf(ArrayNode::class, $node);
+        self::assertTrue($node->key()->eq($tplNode->key()->val()));
+        self::assertTrue($node->path()->eq($tplNode->path()->val()));
+        self::assertSame(['bar'], $node->val());
     }
 }

--- a/tests/unit/Tree/Json/BoolNodeTest.php
+++ b/tests/unit/Tree/Json/BoolNodeTest.php
@@ -12,26 +12,13 @@ final class BoolNodeTest extends TestCase
     /**
      * @test
      */
-    public function it_creates(): void
-    {
-        $node = new BoolNode(new NodeKey('key'), new NodePath('path'), true);
-
-        self::assertInstanceOf(BoolNode::class, $node);
-        self::assertSame('key', $node->key()->val());
-        self::assertSame('path', $node->path()->val());
-        self::assertTrue($node->val());
-    }
-
-    /**
-     * @test
-     */
     public function it_creates_from_another_json_node(): void
     {
-        $node1 = new BoolNode(new NodeKey('key'), new NodePath('path'), true);
-        $node2 = BoolNode::from($node1, false);
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = BoolNode::from($tplNode, false);
 
-        self::assertTrue($node2->key()->eq($node1->key()->val()));
-        self::assertTrue($node2->path()->eq($node1->path()->val()));
-        self::assertFalse($node2->val());
+        self::assertTrue($node->key()->eq($tplNode->key()->val()));
+        self::assertTrue($node->path()->eq($tplNode->path()->val()));
+        self::assertFalse($node->val());
     }
 }

--- a/tests/unit/Tree/Json/FloatNodeTest.php
+++ b/tests/unit/Tree/Json/FloatNodeTest.php
@@ -12,26 +12,13 @@ final class FloatNodeTest extends TestCase
     /**
      * @test
      */
-    public function it_creates(): void
-    {
-        $node = new FloatNode(new NodeKey('key'), new NodePath('path'), 12.34);
-
-        self::assertInstanceOf(FloatNode::class, $node);
-        self::assertSame('key', $node->key()->val());
-        self::assertSame('path', $node->path()->val());
-        self::assertSame(12.34, $node->val());
-    }
-
-    /**
-     * @test
-     */
     public function it_creates_from_another_json_node(): void
     {
-        $node1 = new FloatNode(new NodeKey('key'), new NodePath('path'), 12.34);
-        $node2 = FloatNode::from($node1, 24.68);
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = FloatNode::from($tplNode, 24.68);
 
-        self::assertTrue($node2->key()->eq($node1->key()->val()));
-        self::assertTrue($node2->path()->eq($node1->path()->val()));
-        self::assertSame(24.68, $node2->val());
+        self::assertTrue($node->key()->eq($tplNode->key()->val()));
+        self::assertTrue($node->path()->eq($tplNode->path()->val()));
+        self::assertSame(24.68, $node->val());
     }
 }

--- a/tests/unit/Tree/Json/IntNodeTest.php
+++ b/tests/unit/Tree/Json/IntNodeTest.php
@@ -12,26 +12,13 @@ final class IntNodeTest extends TestCase
     /**
      * @test
      */
-    public function it_creates(): void
-    {
-        $node = new IntNode(new NodeKey('key'), new NodePath('path'), 1234);
-
-        self::assertInstanceOf(IntNode::class, $node);
-        self::assertSame('key', $node->key()->val());
-        self::assertSame('path', $node->path()->val());
-        self::assertSame(1234, $node->val());
-    }
-
-    /**
-     * @test
-     */
     public function it_creates_from_another_json_node(): void
     {
-        $node1 = new IntNode(new NodeKey('key'), new NodePath('path'), 1234);
-        $node2 = IntNode::from($node1, 5678);
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = IntNode::from($tplNode, 5678);
 
-        self::assertTrue($node2->key()->eq($node1->key()->val()));
-        self::assertTrue($node2->path()->eq($node1->path()->val()));
-        self::assertSame(5678, $node2->val());
+        self::assertTrue($node->key()->eq($tplNode->key()->val()));
+        self::assertTrue($node->path()->eq($tplNode->path()->val()));
+        self::assertSame(5678, $node->val());
     }
 }

--- a/tests/unit/Tree/Json/ObjectNodeTest.php
+++ b/tests/unit/Tree/Json/ObjectNodeTest.php
@@ -13,22 +13,6 @@ final class ObjectNodeTest extends TestCase
     /**
      * @test
      */
-    public function it_creates(): void
-    {
-        $c = new stdClass();
-        $c->foo = 'bar';
-
-        $node = new ObjectNode(new NodeKey('key'), new NodePath('path'), $c);
-
-        self::assertInstanceOf(ObjectNode::class, $node);
-        self::assertSame('key', $node->key()->val());
-        self::assertSame('path', $node->path()->val());
-        self::assertEquals($c, $node->val());
-    }
-
-    /**
-     * @test
-     */
     public function it_creates_from_another_json_node(): void
     {
         $c1 = new stdClass();
@@ -36,11 +20,11 @@ final class ObjectNodeTest extends TestCase
         $c2 = new stdClass();
         $c2->foo = 'Y';
 
-        $node1 = new ObjectNode(new NodeKey('key'), new NodePath('path'), $c1);
-        $node2 = ObjectNode::from($node1, $c2);
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = ObjectNode::from($tplNode, $c2);
 
-        self::assertTrue($node2->key()->eq($node1->key()->val()));
-        self::assertTrue($node2->path()->eq($node1->path()->val()));
-        self::assertEquals($c2, $node2->val());
+        self::assertTrue($node->key()->eq($tplNode->key()->val()));
+        self::assertTrue($node->path()->eq($tplNode->path()->val()));
+        self::assertEquals($c2, $node->val());
     }
 }

--- a/tests/unit/Tree/Json/StringNodeTest.php
+++ b/tests/unit/Tree/Json/StringNodeTest.php
@@ -12,26 +12,13 @@ final class StringNodeTest extends TestCase
     /**
      * @test
      */
-    public function it_creates(): void
-    {
-        $node = new StringNode(new NodeKey('key'), new NodePath('path'), 'val');
-
-        self::assertInstanceOf(StringNode::class, $node);
-        self::assertSame('key', $node->key()->val());
-        self::assertSame('path', $node->path()->val());
-        self::assertSame('val', $node->val());
-    }
-
-    /**
-     * @test
-     */
     public function it_creates_from_another_json_node(): void
     {
-        $node1 = new StringNode(new NodeKey('key'), new NodePath('path'), 'foo');
-        $node2 = StringNode::from($node1, 'bar');
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = StringNode::from($tplNode, 'bar');
 
-        self::assertTrue($node2->key()->eq($node1->key()->val()));
-        self::assertTrue($node2->path()->eq($node1->path()->val()));
-        self::assertSame('bar', $node2->val());
+        self::assertTrue($node->key()->eq($tplNode->key()->val()));
+        self::assertTrue($node->path()->eq($tplNode->path()->val()));
+        self::assertSame('bar', $node->val());
     }
 }

--- a/tests/unit/Tree/NodeTest.php
+++ b/tests/unit/Tree/NodeTest.php
@@ -22,7 +22,8 @@ final class NodeTest extends TestCase
      */
     public function it_creates_from_internal_object_node(): void
     {
-        $node = Node::internalObject(new ObjectNode(new NodeKey('key'), new NodePath('path'), new stdClass()));
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = Node::internalObject(ObjectNode::from($tplNode, new stdClass()));
 
         self::assertInstanceOf(Node::class, $node);
         self::assertInstanceOf(ObjectNode::class, $node->getJsonNode());
@@ -34,7 +35,8 @@ final class NodeTest extends TestCase
      */
     public function it_creates_from_internal_array_node(): void
     {
-        $node = Node::internalArray(new ArrayNode(new NodeKey('key'), new NodePath('path'), []));
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+        $node = Node::internalArray(ArrayNode::from($tplNode, []));
 
         self::assertInstanceOf(Node::class, $node);
         self::assertInstanceOf(ArrayNode::class, $node->getJsonNode());
@@ -46,11 +48,13 @@ final class NodeTest extends TestCase
      */
     public function it_creates_from_leaf_json_node(): void
     {
-        $nullNode = Node::leaf(new NullNode(new NodeKey('key'), new NodePath('path')));
-        $boolNode = Node::leaf(new BoolNode(new NodeKey('key'), new NodePath('path'), true));
-        $intNode = Node::leaf(new IntNode(new NodeKey('key'), new NodePath('path'), 1234));
-        $floatNode = Node::leaf(new FloatNode(new NodeKey('key'), new NodePath('path'), 12.34));
-        $stringNode = Node::leaf(new StringNode(new NodeKey('key'), new NodePath('path'), 'val'));
+        $tplNode = new NullNode(new NodeKey('key'), new NodePath('path'));
+
+        $nullNode = Node::leaf($tplNode);
+        $boolNode = Node::leaf(BoolNode::from($tplNode, true));
+        $intNode = Node::leaf(IntNode::from($tplNode, 1234));
+        $floatNode = Node::leaf(FloatNode::from($tplNode, 12.34));
+        $stringNode = Node::leaf(StringNode::from($tplNode, 'val'));
 
         self::assertInstanceOf(Node::class, $nullNode);
         self::assertInstanceOf(Node::class, $boolNode);


### PR DESCRIPTION
All but NullNode can now only be created from another node.
This way the one and only way to mutate node key/path is to purposefully
use a new NullNode with arbitrary key/path values.

This enables a tight control over key/path while not restricting usage
in any way.